### PR TITLE
Adds a deps.edn file

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,2 @@
+{:deps {org.clojure/clojure       #:mvn {:version "1.10.1"}
+        org.freemarker/freemarker #:mvn {:version "2.3.30"}}}


### PR DESCRIPTION
Adds a `deps.edn` file, so that the library can be used from `tools.deps` via a [Git library dependency](https://clojure.org/guides/deps_and_cli#_using_git_libraries).

Note: this addresses issue #9 for `tools.deps` users (though not Leiningen users).